### PR TITLE
Add description using React Helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15266,6 +15266,11 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "pngjs": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jquery": "^3.4.1",
     "lodash": "^4.17.15",
     "node-sass": "^4.13.1",
+    "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",

--- a/src/pages/flavor.js
+++ b/src/pages/flavor.js
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
 import { graphql, Link } from 'gatsby';
 import React, { Component, Fragment } from 'react';
@@ -45,7 +46,8 @@ export default class FlavorPage extends Component {
     return (
       <Fragment>
         <h6 className="mt-3">
-          This flavor contains the following concerning ingredients:
+          This flavor contains the following concerning{' '}
+          {pluralize('ingredient', ingredients.length)}:
         </h6>
         <ListGroup activeKey="">
           {ingredients.map(ingredient => (
@@ -65,11 +67,16 @@ export default class FlavorPage extends Component {
   }
 
   render() {
-    const { flavor, vendor } = this.state;
+    const { flavor, ingredients, vendor } = this.state;
+
+    const title = `Flavor Info - ${flavor.name}`;
+    const description = `${flavor.name} contains ${
+      ingredients.length
+    } concerning ${pluralize('ingredient', ingredients.length)}.`;
 
     return (
       <Layout>
-        <SEO title={`Flavor Info - ${flavor.name}`} />
+        <SEO title={title} description={description} />
         <Container>
           <Row className="mb-3">
             <Col>

--- a/src/pages/ingredient.js
+++ b/src/pages/ingredient.js
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
 import { graphql, Link } from 'gatsby';
 import React, { Component } from 'react';
@@ -16,21 +17,30 @@ export default class IngredientPage extends Component {
     super(props);
 
     const {
-      data: { ingredient, flavors }
+      data: { ingredient, flavors, vendors }
     } = this.props;
 
     this.state = {
       ingredient,
-      flavors: flavors.nodes
+      flavors: flavors.nodes,
+      vendors: vendors.nodes
     };
   }
 
   render() {
-    const { ingredient, flavors } = this.state;
+    const { flavors, ingredient, vendors } = this.state;
+
+    const title = `Ingredient Info - ${ingredient.name}`;
+    const description = `${ingredient.name} is used by ${
+      vendors.length
+    } ${pluralize('vendor', vendors.length)} in ${flavors.length} ${pluralize(
+      'flavor',
+      flavors.length
+    )}.`;
 
     return (
       <Layout>
-        <SEO title={`Ingredient Info - ${ingredient.name}`} />
+        <SEO title={title} description={description} />
         <Container>
           <Row className="mb-3">
             <Col>

--- a/src/pages/vendor.js
+++ b/src/pages/vendor.js
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
 import { graphql, Link } from 'gatsby';
 import React, { Component } from 'react';
@@ -29,9 +30,16 @@ export default class VendorPage extends Component {
   render() {
     const { flavors, ingredients, vendor } = this.state;
 
+    const title = `Vendor Info - ${vendor.name}`;
+    const description = `${vendor.name} uses ${
+      ingredients.length
+    } concerning ${pluralize('ingredient', ingredients.length)} in ${
+      flavors.length
+    } ${pluralize('flavor', flavors.length)}.`;
+
     return (
       <Layout>
-        <SEO title={`Vendor Info - ${vendor.name}`} />
+        <SEO title={title} description={description} />
         <Container>
           <Row className="mb-3">
             <Col>


### PR DESCRIPTION
This PR adds description meta fields to the document header, so that for example Discord will pull in a useful string when embedding meta info about a link. It adds the pluralize package to handle conditional pluralization of some of the words in the descriptions.